### PR TITLE
:bug: Fix missing attribute error on Unity 2019

### DIFF
--- a/Editor/MaterialImporterWindow.cs
+++ b/Editor/MaterialImporterWindow.cs
@@ -11,7 +11,9 @@ using UnityEngine.UIElements;
 
 namespace HestiaMaterialImporter.Editor
 {
+#if UNITY_2020_2_OR_NEWER
     [EditorWindowTitle(title = "Material Importer", icon = "Material Icon")]
+#endif
     public class MaterialImporterWindow : EditorWindow
     {
 


### PR DESCRIPTION
EditorWindowTitleAttribute does not exist in Unity 2019 and earlier
I don't know what it does, but I don't see any issues with the title on Unity 2019.4.14f